### PR TITLE
feat: add request-id to error responses

### DIFF
--- a/.github/codegen/schemas/swagger.json
+++ b/.github/codegen/schemas/swagger.json
@@ -1230,6 +1230,7 @@
             "in": "query",
             "description": "Continuation token from previous incomplete call",
             "schema": {
+              "maxLength": 50,
               "type": "string"
             }
           },
@@ -1238,7 +1239,7 @@
             "in": "query",
             "description": "Maximum number of keys returned in one call",
             "schema": {
-              "maximum": 500,
+              "maximum": 100,
               "minimum": 10,
               "type": "integer",
               "format": "int32",
@@ -2537,12 +2538,14 @@
         "properties": {
           "error_id": {
             "type": "string",
-            "description": "Error id"
+            "description": "Error id",
+            "readOnly": true
           },
           "error_code": {
             "type": "integer",
             "description": "Error code",
-            "format": "int32"
+            "format": "int32",
+            "readOnly": true
           },
           "errors": {
             "type": "array",
@@ -2550,6 +2553,11 @@
               "type": "string"
             },
             "description": "List with text error messages associated with ErrorId",
+            "readOnly": true
+          },
+          "request_id": {
+            "type": "string",
+            "description": "Request id",
             "readOnly": true
           }
         },

--- a/.github/codegen/schemas/version.txt
+++ b/.github/codegen/schemas/version.txt
@@ -1,1 +1,1 @@
-0.9.14 (manually modified)
+0.9.16 (manually modified)

--- a/errors.go
+++ b/errors.go
@@ -187,6 +187,7 @@ type KmsError struct {
 	ErrorCode ErrorCode
 	ErrorId   string
 	Errors    []error
+	RequestId string
 }
 
 func NewKmsErrorFromBytes(sbody []byte) *KmsError {
@@ -210,13 +211,16 @@ func newKmsErrorFromRestResponse(resp types.ErrorResponse) *KmsError {
 			kmsErr.Errors = append(kmsErr.Errors, errors.New(er))
 		}
 	}
+	if resp.RequestId != nil {
+		kmsErr.RequestId = *resp.RequestId
+	}
 	return kmsErr
 }
 
 func (err *KmsError) Error() string {
 	errs := make([]error, 0, len(err.Errors)+1)
 	errs = append(errs, err.Errors...)
-	errs = append(errs, fmt.Errorf("ID=%s, %s", err.ErrorId, err.ErrorCode))
+	errs = append(errs, fmt.Errorf("ID=%q, Request-ID:%q, %s", err.ErrorId, err.RequestId, err.ErrorCode))
 	return errors.Join(errs...).Error()
 }
 

--- a/types/types.gen.go
+++ b/types/types.gen.go
@@ -171,6 +171,9 @@ type ErrorResponse struct {
 
 	// Errors List with text error messages associated with ErrorId
 	Errors *[]string `json:"errors,omitempty"`
+
+	// RequestId Request id
+	RequestId *string `json:"request_id,omitempty"`
 }
 
 // GenerateDataKeyRequest Generate data key shortcut helper


### PR DESCRIPTION
Add the request id to HTTP error response body as per the latest KMS openapi spec