### PR TITLE
Allow Errors nil in KmsErrors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -193,7 +193,7 @@ type KmsError struct {
 
 func NewKmsErrorFromBytes(sbody []byte) *KmsError {
 	var errResp types.ErrorResponse
-	if e := json.Unmarshal(sbody, &errResp); e == nil && errResp.Errors != nil {
+	if e := json.Unmarshal(sbody, &errResp); e == nil {
 		return newKmsErrorFromRestResponse(errResp)
 	}
 	return nil


### PR DESCRIPTION
When the rest return an error with `errors` field null, it produces a nil `KmsError` instead of one with `Errors` at nil. 
This behavior led to unexpected dereferencement error later in the code. 

Changed the behavior to allow `KmsError` with nil `Errors` 